### PR TITLE
changing bad translation of "class" and "racial"

### DIFF
--- a/words.html
+++ b/words.html
@@ -612,7 +612,7 @@ dominiert <span class="all_d">IMMER BETRÜGEN</span>.
 <br><br>
 Als in 1985 Amerikaner gefragt wurden, wie viele enge Freunde sie haben,
 sagten die meisten "3". In 2004, waren es <i>"0"</i>.
-Wir haben heute weniger Freundschaften über die Grenzen von Klasse, Rasse, Vermögen und Politik hinweg, weil wir weniger Freunde haben -- <i>Punkt.</i>
+Wir haben heute weniger Freundschaften über die Grenzen von ethnischen und sozialen Gruppierungen, Vermögen und Politik hinweg, weil wir weniger Freunde haben -- <i>Punkt.</i>
 Und wie du selbst gerade entdeckt hast,
 <b>weniger "wiederholte Interaktionen" führen zu mehr Misstrauen.</b>
 <br><br>


### PR DESCRIPTION
The english word "race" should not be translated with "Rasse" but with a scientifically correct and meaningful term.
For example, Asians and Africans are not different species but differ very slightly because of geological and social distance.

Using "Klasse" to describe social separations in society is also bad wording.

Changes are limited to these two words only.